### PR TITLE
Rename the Project

### DIFF
--- a/.github/workflows/ci-general.yml
+++ b/.github/workflows/ci-general.yml
@@ -13,6 +13,8 @@ jobs:
         python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     runs-on: ubuntu-latest
+    container:
+      image: verilator/verilator:v5.018
 
     steps:
     - name: Checkout Source Code
@@ -21,24 +23,20 @@ jobs:
     # Installation of Binary Dependencies
     - name: Install Poetry
       run: |
-        curl -sSL https://install.python-poetry.org | python
-        echo "${HOME}/.poetry/bin" >> $GITHUB_PATH
+        apt-get update; apt-get install -y curl sudo
+        curl -sSL https://install.python-poetry.org | python3
+        ln -sf "${HOME}/.local/bin/poetry" /usr/bin/poetry
 
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'poetry'
-    - name: Install Verilator
+
+    - name: Hack on Verilator
       run: |
-        sudo apt install libjs-underscore libjs-jquery fonts-font-awesome fonts-lato
-        wget -q http://mirrors.kernel.org/ubuntu/pool/main/s/sphinx/libjs-sphinxdoc_5.3.0-4_all.deb
-        wget -q http://mirrors.kernel.org/ubuntu/pool/main/s/sphinx-rtd-theme/sphinx-rtd-theme-common_1.3.0+dfsg-1_all.deb
-        wget -q http://mirrors.kernel.org/ubuntu/pool/universe/v/verilator/verilator_5.012-1_amd64.deb
-        sudo dpkg -i sphinx-rtd-theme-common_1.3.0+dfsg-1_all.deb libjs-sphinxdoc_5.3.0-4_all.deb verilator_5.012-1_amd64.deb
-        
         export CUR_PYTHON=$(poetry run which python)
-        sudo ln -sf $CUR_PYTHON /usr/bin/python3
+        ln -sf $CUR_PYTHON /usr/bin/python3
 
     # Verify version of installed binaries
     - name: List Poetry Environment

--- a/.github/workflows/ci-general.yml
+++ b/.github/workflows/ci-general.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.11" ]
 
     runs-on: ubuntu-latest
     container:
@@ -42,7 +42,7 @@ jobs:
       env:
         pytest_github_report: true
       run: |
-        poetry run pytest -n auto tests
+        poetry run pytest tests
 
 
   Deploy:

--- a/.github/workflows/ci-general.yml
+++ b/.github/workflows/ci-general.yml
@@ -23,8 +23,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        cache: 'poetry'
-        cache-dependency-path: poetry.lock
     - name: Install Poetry
       uses: snok/install-poetry@v1
     - name: Install Verilator

--- a/.github/workflows/ci-general.yml
+++ b/.github/workflows/ci-general.yml
@@ -51,6 +51,9 @@ jobs:
     needs:
       - RunTests
     if: ${{ startsWith(github.ref, 'refs/tags/v') && success() }}
+    environment: release
+    permissions:
+      id-token: write
 
     steps:
     - name: Checkout Source
@@ -73,7 +76,9 @@ jobs:
       run: |
        poetry config pypi-token.pypi "$PYPI_TOKEN" 
 
-    - name: Publish to PyPi
+    - name: Build Package
       run: |
         poetry build
-        poetry publish
+
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/ci-general.yml
+++ b/.github/workflows/ci-general.yml
@@ -19,12 +19,16 @@ jobs:
       uses: actions/checkout@v4
 
     # Installation of Binary Dependencies
+    - name: Install Poetry
+      run: |
+        curl -sSL https://install.python-poetry.org | python
+        echo "${HOME}/.poetry/bin" >> $GITHUB_PATH
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Poetry
-      uses: snok/install-poetry@v1
+        cache: 'poetry'
     - name: Install Verilator
       run: |
         sudo apt install libjs-underscore libjs-jquery fonts-font-awesome fonts-lato

--- a/.github/workflows/ci-general.yml
+++ b/.github/workflows/ci-general.yml
@@ -10,44 +10,65 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.11" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
 
     runs-on: ubuntu-latest
-    container:
-      image: verilator/verilator:v5.018
 
     steps:
     - name: Checkout Source Code
       uses: actions/checkout@v4
-    - name: Print Verilator version
-      run: |
-        verilator --version
-    - name: Set up Python ${{ matrix.python-version }}
+
+    # Installation of Binary Dependencies
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install Poetry
-      run: |
-        python3 -m pip install poetry
-    - name: Set up Poetry
-      uses: actions/setup-python@v5
-      with:
-        python-version: "3.10"
         cache: 'poetry'
         cache-dependency-path: poetry.lock
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+    - name: Install Verilator
+      run: |
+        sudo apt install libjs-underscore libjs-jquery fonts-font-awesome fonts-lato
+        wget -q http://mirrors.kernel.org/ubuntu/pool/main/s/sphinx/libjs-sphinxdoc_5.3.0-4_all.deb
+        wget -q http://mirrors.kernel.org/ubuntu/pool/main/s/sphinx-rtd-theme/sphinx-rtd-theme-common_1.3.0+dfsg-1_all.deb
+        wget -q http://mirrors.kernel.org/ubuntu/pool/universe/v/verilator/verilator_5.012-1_amd64.deb
+        sudo dpkg -i sphinx-rtd-theme-common_1.3.0+dfsg-1_all.deb libjs-sphinxdoc_5.3.0-4_all.deb verilator_5.012-1_amd64.deb
+        
+        export CUR_PYTHON=$(poetry run which python)
+        sudo ln -sf $CUR_PYTHON /usr/bin/python3
+
+    # Verify version of installed binaries
+    - name: List Poetry Environment
+      run: |
+        poetry env list
+    - name: Print Poetry Environment
+      run: |
+        poetry env info
+    - name: Print Verilator version
+      run: |
+        verilator --version
+    - name: Python Version
+      run: |
+        python --version
+    - name: Python with Poetry Version
+      run: |
+        poetry run python --version
+
     - name: Install dependencies
       run: |
         poetry install --no-interaction  --with=dev
+
     - name: Run Pytest
       env:
         pytest_github_report: true
       run: |
-        poetry run pytest tests
+        poetry run pytest -n auto tests
 
 
   Deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - RunTests
     if: ${{ startsWith(github.ref, 'refs/tags/v') && success() }}
@@ -58,23 +79,33 @@ jobs:
     steps:
     - name: Checkout Source
       uses: actions/checkout@v4
-    - name: Install poetry
-      run: pipx install poetry
-    - name: Set up Poetry
+
+    # Installation of Binary Dependencies
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: "3.10"
-        cache: 'poetry'
-        cache-dependency-path: poetry.lock
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+
+    # Verify version of installed binaries
+    - name: List Poetry Environment
+      run: |
+        poetry env list
+    - name: Print Poetry Environment
+      run: |
+        poetry env info
+    - name: Python Version
+      run: |
+        python --version
+    - name: Python with Poetry Version
+      run: |
+        poetry run python --version
+
+
     - name: Install dependencies
       run: |
         poetry install --no-interaction  --with=dev
-
-    - name: Setup Credential
-      env:
-        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |
-       poetry config pypi-token.pypi "$PYPI_TOKEN" 
 
     - name: Build Package
       run: |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Please refer to the [Magia Roadmap](docs/roadmap.md).
 
 ```bash
 pip install magia-hdl
+
+# Install with full dependencies if advanced features are required
+
+pip install magia-hdl[full]
 ```
 
 ## Examples

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Please refer to the [Magia Roadmap](docs/roadmap.md).
 ## Installation
 
 ```bash
-pip install syn-magia
+pip install magia-hdl
 ```
 
 ## Examples

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -21,9 +21,9 @@ Pull requests are the best way to propose changes to the codebase (we use [Githu
 5. Lint your code with `ruff check`.
 6. Issue that pull request!
 
-## Report bugs using GitHub [issues](https://github.com/khwong-c/syn-magia/issues)
+## Report bugs using GitHub [issues](https://github.com/magia-hdl/magia/issues)
 We use GitHub issues to track public bugs. 
-Report a bug by [opening a new issue](https://github.com/khwong-c/syn-magia/issues/new); it's that easy!
+Report a bug by [opening a new issue](https://github.com/magia-hdl/magia/issues/new); it's that easy!
 
 ## Write bug reports with detail, background, and sample code
 **Great Bug Reports** tend to have:

--- a/docs/external_module.md
+++ b/docs/external_module.md
@@ -12,7 +12,16 @@ Common Use-cases are importing IP core such as:
 
 ## Prerequisite
 
-We need to install [hdlConvertor](https://github.com/Nic30/hdlConvertor) for this feature.
+This feature requires extra packages to be installed.
+Install with full features by running:
+
+```bash
+pip install magia-hdl[full]
+```
+
+Or install the following packages manually:
+
+- [hdlConvertor](https://github.com/Nic30/hdlConvertor)
 
 Run the following command to install hdlConvertor, if you are running on Linux X86_64:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ ignore = ["F821", "A003"]
 "tests/**" = ["S101", "S311"]
 
 [tool.poetry]
-name = "syn-magia"
+name = "magia-hdl"
 version = "0.3.0"
 description = "Magia generates Synthesizable SystemVerilog in pythonic syntax"
 readme = "README.md"
@@ -50,7 +50,7 @@ ruff = "*"
 hdlConvertor-binary = "~2.3"
 
 [project.urls]
-Repository = "https://github.com/khwong-c/syn-magia"
+Repository = "https://github.com/magia-hdl/magia"
 
 [tool.pytest.ini_options]
 norecursedirs = "tests/helpers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,12 @@ keywords = [
     "Code Generation", "FPGA", "ASIC", "EDA", "RTL Design"
 ]
 
+[tool.poetry.extras]
+full = ["hdlConvertor-binary"]
+
 [tool.poetry.dependencies]
 python = "^3.9"
+hdlConvertor-binary = { version = "~2.3", optional=true }
 
 [tool.poetry.group.dev.dependencies]
 cocotb = "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,4 @@ Repository = "https://github.com/magia-hdl/magia"
 
 [tool.pytest.ini_options]
 norecursedirs = "tests/helpers"
+log_cli=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ pytest-github-report = "*"
 ruff = "*"
 hdlConvertor-binary = "~2.3"
 
-[project.urls]
+[tool.poetry.urls]
 Repository = "https://github.com/magia-hdl/magia"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,4 @@ Repository = "https://github.com/magia-hdl/magia"
 
 [tool.pytest.ini_options]
 norecursedirs = "tests/helpers"
-log_cli=true
+log_cli=false  # turn to true to enable debug logging


### PR DESCRIPTION
- Rename PyPi Package to `magia-hdl`
- Changing the Repo location and URL in documentation/configs
- Fixing on CI Pipeline. The test was running only on Python 3.10
- Verilator causing #19. Dirty Fix on Rerouting `/usr/bin/python3`
- Add installation option `pip install magia-hdl[full]`

Remark:
Running CI on verilator docker image is significantly faster on the CI Runner.

Closing #19. Close #15 as well after Registering the Domain