### PR TITLE
Patch Script: Mounting Verilator into the virtualenv

### DIFF
--- a/.github/workflows/ci-general.yml
+++ b/.github/workflows/ci-general.yml
@@ -33,11 +33,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'poetry'
 
-    - name: Hack on Verilator
-      run: |
-        export CUR_PYTHON=$(poetry run which python)
-        ln -sf $CUR_PYTHON /usr/bin/python3
-
     # Verify version of installed binaries
     - name: List Poetry Environment
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,4 +58,4 @@ Repository = "https://github.com/magia-hdl/magia"
 
 [tool.pytest.ini_options]
 norecursedirs = "tests/helpers"
-log_cli=false  # turn to true to enable debug logging
+log_cli=true  # turn to true to enable debug logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,4 +58,4 @@ Repository = "https://github.com/magia-hdl/magia"
 
 [tool.pytest.ini_options]
 norecursedirs = "tests/helpers"
-log_cli=true  # turn to true to enable debug logging
+log_cli = false  # turn to true to enable debug logging

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,10 @@ from tempfile import TemporaryDirectory
 
 import pytest
 
+from .helper import init_verilator
+
+init_verilator()
+
 
 @pytest.fixture()
 def temp_build_dir():

--- a/tests/helper/__init__.py
+++ b/tests/helper/__init__.py
@@ -54,6 +54,13 @@ def parameterized_testbench(test_function, test_opts_val) -> tuple[Callable, lis
 
 
 def init_verilator():
+    if not shutil.which("verilator"):
+        raise RuntimeError("Verilator not found in PATH")
+
+    version = subprocess.check_output(["verilator", "--version"]).decode().strip().split()[1]
+    if float(version) < 5.006:
+        raise RuntimeError("Verilator version >= 5.006 is required")
+
     # Skip if not in venv
     if sys.base_prefix == sys.prefix:
         return
@@ -61,14 +68,18 @@ def init_verilator():
     # Check if verilator is already copied into venv
     verilator_mounted = Path(sys.prefix, "bin", "verilator").exists()
     if not verilator_mounted:
+        # Locate Verilator binaries and the original VERILATOR_ROOT
         verilator_bin_location = Path(shutil.which("verilator_bin")).parent
         verilator_root = Path(subprocess.check_output(["verilator", "--getenv", "VERILATOR_ROOT"]).decode().strip())
         verilator_bins = list(verilator_bin_location.glob("verilator*"))
 
+        # Copy files into venv
         shutil.copytree(verilator_root, Path(sys.prefix), dirs_exist_ok=True)
         for path in verilator_bins:
             shutil.copy(path, Path(sys.prefix, "bin"))
 
+        # Patch verilated.mk
+        # Replace the Python3 interpreter with the one in venv
         makefile_in = Path(sys.prefix, "include", "verilated.mk")
         makefile_content = makefile_in.read_text().splitlines()
         for i, line in enumerate(makefile_content):

--- a/tests/helper/__init__.py
+++ b/tests/helper/__init__.py
@@ -1,6 +1,11 @@
 import functools
 import inspect
+import os
+import shutil
+import subprocess
+import sys
 from contextlib import contextmanager
+from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Callable
 
@@ -48,7 +53,35 @@ def parameterized_testbench(test_function, test_opts_val) -> tuple[Callable, lis
     return test_generator, pytest_param, pytest_param_val
 
 
+def init_verilator():
+    # Skip if not in venv
+    if sys.base_prefix == sys.prefix:
+        return
+
+    # Check if verilator is already copied into venv
+    verilator_mounted = Path(sys.prefix, "bin", "verilator").exists()
+    if not verilator_mounted:
+        verilator_bin_location = Path(shutil.which("verilator_bin")).parent
+        verilator_root = Path(subprocess.check_output(["verilator", "--getenv", "VERILATOR_ROOT"]).decode().strip())
+        verilator_bins = list(verilator_bin_location.glob("verilator*"))
+
+        shutil.copytree(verilator_root, Path(sys.prefix), dirs_exist_ok=True)
+        for path in verilator_bins:
+            shutil.copy(path, Path(sys.prefix, "bin"))
+
+        makefile_in = Path(sys.prefix, "include", "verilated.mk")
+        makefile_content = makefile_in.read_text().splitlines()
+        for i, line in enumerate(makefile_content):
+            if line.startswith("PYTHON3 ="):
+                makefile_content[i] = f"PYTHON3 = {sys.executable}"
+        makefile_in.write_text("\n".join(makefile_content))
+
+    # Override VERILATOR_ROOT
+    os.environ["VERILATOR_ROOT"] = sys.prefix
+
+
 __all__ = [
     "elaborate_to_file",
     "parameterized_testbench",
+    "init_verilator",
 ]

--- a/tests/helper/__init__.py
+++ b/tests/helper/__init__.py
@@ -74,6 +74,7 @@ def init_verilator():
         for i, line in enumerate(makefile_content):
             if line.startswith("PYTHON3 ="):
                 makefile_content[i] = f"PYTHON3 = {sys.executable}"
+                break
         makefile_in.write_text("\n".join(makefile_content))
 
     # Override VERILATOR_ROOT


### PR DESCRIPTION
This Helper function 
- copies Verilator and its included files into the virtual environment
- Patch the Verilator Makefile with the Python interpreter in the virtual environment

This solves the Python mismatch problem encountered before, without the dirty relinking on the system Python interpreter.