### PR TITLE
Verilog Wrapper generator

### DIFF
--- a/magia/__init__.py
+++ b/magia/__init__.py
@@ -3,7 +3,7 @@ from importlib.util import find_spec
 from .bundle import Bundle, BundleSpec, BundleType
 from .core import Constant, Input, Output, Register, Signal
 from .memory import Memory
-from .module import Blackbox, Elaborator, Instance, IOPorts, Module
+from .module import Blackbox, Elaborator, Instance, IOPorts, Module, VerilogWrapper
 
 if find_spec("hdlConvertor") is not None:
     from .external import ExternalModule
@@ -53,6 +53,7 @@ __all__ += [
     "Blackbox",
     "Elaborator",
     "ExternalModule",
+    "VerilogWrapper",
 ]
 
 """


### PR DESCRIPTION
`VerilogWrapper` wrap on top of a `Module`.

It instantiates the given Module (specialized) and wires it with the same I/O Ports.
The I/O Ports are declared in Verilog syntax `wire` instead of `logic`.

This allows us to integrate with EDA tools, which requires the top level must be a Verilog file (e.g. Vivado IP Integrator).

Example:
```python
from magia import Module, VerilogWrapper
class Design(Module):
  ...

top_level = Design(name="TopLevel")
Elaborator.to_file("TopLevel.sv", top_level)  # Elaborate the whole design to the SV file
Elaborator.to_file(
  "TopLevelWrapper.v", 
  VerilogWrapper(top_level),
  top_only=True,
)  # Elaborate the Verilog wrapper to the Verilog file
```

We can then import both Files with EDA tools, and the Verilog wrapper as top-level.
![image](https://github.com/magia-hdl/magia/assets/92428218/8d0a4c46-cf2a-426b-95ee-8a28e01875af)
