### PR TITLE
Drop Python 3.9

### DIFF
--- a/.github/workflows/ci-general.yml
+++ b/.github/workflows/ci-general.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci-general.yml
+++ b/.github/workflows/ci-general.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
 
     runs-on: ubuntu-latest
     container:

--- a/.github/workflows/ci-general.yml
+++ b/.github/workflows/ci-general.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.10", "3.11", "3.12" ]
 
     runs-on: ubuntu-latest
     container:

--- a/poetry.lock
+++ b/poetry.lock
@@ -700,5 +700,5 @@ full = ["hdlConvertor-binary"]
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9"
-content-hash = "775741c5285ed4461bcd2eba0baf0c8a9693c51cddbd617d3796c95c4e999030"
+python-versions = "^3.10"
+content-hash = "d9da39fbfe3f7b5354247852f621f3758ea393c62b029661ada6ebbf49d9134d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ keywords = [
 full = ["hdlConvertor-binary"]
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 hdlConvertor-binary = { version = "~2.3", optional = true }
 antlr4-python3-runtime = "4.13.1"
 


### PR DESCRIPTION
##  Changes
This drops the test for Python 3.9. We will move on to Python 3.10