### PR TITLE
Fix: Missing Signal Declaration for Unused Instance Output

### DIFF
--- a/magia/module.py
+++ b/magia/module.py
@@ -34,6 +34,11 @@ class ModuleInstanceConfig:
     name: None | str = None
 
 
+MOD_DECL_TEMPLATE = Template("module $name (\n$io\n);")
+INST_TEMPLATE = Template("$module_name $inst_name (\n$io\n);")
+IO_TEMPLATE = Template(".$port_name($signal_name)")
+
+
 class IOPorts:
     """
     Define a set of I/O, which can be used as the input or output of a module.
@@ -175,7 +180,6 @@ class Module(Synthesizable):
         self.io.q <<= self.io.a + 1
     """
 
-    _MOD_DECL_TEMPLATE = Template("module $name (\n$io\n);")
     _new_module_counter = count(0)
     output_file: None | PathLike = None
 
@@ -217,7 +221,7 @@ class Module(Synthesizable):
         return []
 
     def mod_declaration(self) -> str:
-        mod_decl = self._MOD_DECL_TEMPLATE.substitute(
+        mod_decl = MOD_DECL_TEMPLATE.substitute(
             name=self.name,
             io=",\n".join(
                 port.elaborate()
@@ -459,9 +463,6 @@ class Module(Synthesizable):
 class Instance(Synthesizable):
     """An instance of a module."""
 
-    _INST_TEMPLATE = Template("$module_name $inst_name (\n$io\n);")
-    _IO_TEMPLATE = Template(".$port_name($signal_name)")
-
     _new_inst_counter = count(0)
 
     def __init__(self,
@@ -542,10 +543,10 @@ class Instance(Synthesizable):
             if port.type == SignalType.INPUT:
                 signal_name = port.driver().name
 
-            io_list.append(self._IO_TEMPLATE.substitute(port_name=port_name, signal_name=signal_name))
+            io_list.append(IO_TEMPLATE.substitute(port_name=port_name, signal_name=signal_name))
 
         io_list = ",\n".join(io_list)
-        return self._INST_TEMPLATE.substitute(
+        return INST_TEMPLATE.substitute(
             module_name=module_name,
             inst_name=inst_name,
             io=io_list,

--- a/magia/module.py
+++ b/magia/module.py
@@ -308,16 +308,17 @@ class Module(Synthesizable):
                         traced_inst_id.add(id(inst))
                         traced_inst.append(inst)
 
-                        # The Input port of the instance is skipped
-                        # We will go directly to the driver as it must be driven by another signal.
-                        input_drivers = [
-                            i.driver()
-                            for i in inst.io.values()
-                            if i.type == SignalType.INPUT
+                        # Trace the IO Ports of an instance.
+                        # Input port is driven by external signal, so we go for the driver.
+                        # Output port is an extra signal placeholder,
+                        # so we add the port itself and ensure the declaration exists.
+                        port_drivers = [
+                            port.driver() if port.type == SignalType.INPUT else port
+                            for port in inst.io.values()
                         ]
                         next_trace |= {
                             id_sig: sig
-                            for sig in input_drivers
+                            for sig in port_drivers
                             if (id_sig := id(sig)) not in traced_sig_id
                         }
                 elif signal.type != SignalType.INPUT and signal_id not in traced_sig_id:

--- a/tests/test_module_instance.py
+++ b/tests/test_module_instance.py
@@ -76,88 +76,87 @@ class TestModSpecialize:
         assert len(result) == 2, f"Expected 2 modules: Top + 1 SubModules, got {len(result)} modules."
 
 
-def test_elaborate_to_files(temp_build_dir):
-    adder_file = "adder.sv"
+class TestElaboration:
+    def test_elaborate_to_files(self, temp_build_dir):
+        adder_file = "adder.sv"
 
-    @Elaborator.file(adder_file)
-    class Adder(Module):
-        def __init__(self, **kwargs):
-            super().__init__(**kwargs)
-            self.io += Input("a", 4)
-            self.io += Input("b", 4)
-            self.io += Output("q", 5, signed=True)
+        @Elaborator.file(adder_file)
+        class Adder(Module):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.io += Input("a", 4)
+                self.io += Input("b", 4)
+                self.io += Output("q", 5, signed=True)
 
-            self.io.q <<= (self.io.a + self.io.b).set_width(5)
+                self.io.q <<= (self.io.a + self.io.b).set_width(5)
 
-    class Top(Module):
-        def __init__(self, **kwargs):
-            super().__init__(**kwargs)
-            self.io += Input("a", 4)
-            self.io += Input("b", 4)
-            self.io += Output("q0", 5, signed=True)
-            self.io += Output("q1", 5, signed=True)
-            self.io += Output("q2", 5, signed=True)
+        class Top(Module):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.io += Input("a", 4)
+                self.io += Input("b", 4)
+                self.io += Output("q0", 5, signed=True)
+                self.io += Output("q1", 5, signed=True)
+                self.io += Output("q2", 5, signed=True)
 
-            Adder().instance("adder1", io={"a": self.io.a, "b": self.io.b, "q": self.io.q0})
-            Adder().instance("adder2", io={"a": self.io.a, "b": self.io.b, "q": self.io.q1})
-            Adder().instance("adder3", io={"a": self.io.a, "b": self.io.b, "q": self.io.q2})
+                Adder().instance("adder1", io={"a": self.io.a, "b": self.io.b, "q": self.io.q0})
+                Adder().instance("adder2", io={"a": self.io.a, "b": self.io.b, "q": self.io.q1})
+                Adder().instance("adder3", io={"a": self.io.a, "b": self.io.b, "q": self.io.q2})
 
-    elaborated = Elaborator.to_files(temp_build_dir, Top(name="Top"), Top(name="Top2"), force=True)
-    elaborated = [file.name for file in elaborated]
-    assert len(elaborated) == 3, f"Expected 3 files, got {len(elaborated)} files."
-    assert "Top.sv" in elaborated, "Top.sv is missing."
-    assert "Top2.sv" in elaborated, "Top2.sv is missing."
-    assert adder_file in elaborated, f"{adder_file} is missing."
+        elaborated = Elaborator.to_files(temp_build_dir, Top(name="Top"), Top(name="Top2"), force=True)
+        elaborated = [file.name for file in elaborated]
+        assert len(elaborated) == 3, f"Expected 3 files, got {len(elaborated)} files."
+        assert "Top.sv" in elaborated, "Top.sv is missing."
+        assert "Top2.sv" in elaborated, "Top2.sv is missing."
+        assert adder_file in elaborated, f"{adder_file} is missing."
 
-    adder_conetxt = Path(temp_build_dir, adder_file).read_text()
-    end_modules = [
-        line for line in adder_conetxt.splitlines()
-        if line.strip() == "endmodule"
-    ]
-    assert len(end_modules) == 6, f"Expected 6 modules in {adder_file}, got {len(end_modules)}."
+        adder_conetxt = Path(temp_build_dir, adder_file).read_text()
+        end_modules = [
+            line for line in adder_conetxt.splitlines()
+            if line.strip() == "endmodule"
+        ]
+        assert len(end_modules) == 6, f"Expected 6 modules in {adder_file}, got {len(end_modules)}."
 
+    def test_elaborate_doc(self):
+        class Top(Module):
+            """This is a top module."""
 
-def test_elaborate_doc():
-    class Top(Module):
-        """This is a top module."""
+            def __init__(self, width, **kwargs):
+                super().__init__(**kwargs)
+                self.io += Input("a", width)
+                self.io += Output("b", width)
+                self.io.b <<= self.io.a
 
-        def __init__(self, width, **kwargs):
-            super().__init__(**kwargs)
-            self.io += Input("a", width)
-            self.io += Output("b", width)
-            self.io.b <<= self.io.a
+        doc = Elaborator.to_string(Top(width=7086))
+        assert "This is a top module." in doc, "Module doc is missing."
+        assert "width: 7086" in doc, "Module parameter is missing."
 
-    doc = Elaborator.to_string(Top(width=7086))
-    assert "This is a top module." in doc, "Module doc is missing."
-    assert "width: 7086" in doc, "Module parameter is missing."
+    def test_module_spec(self):
+        class Top(Module):
+            """This is a top module."""
 
+            def __init__(self, width, **kwargs):
+                """:param width: The width of the module."""
+                super().__init__(**kwargs)
+                self.io += Input("a", width, description="Input A")
+                self.io += Output("b", width)
+                self.io.b <<= self.io.a
 
-def test_module_spec():
-    class Top(Module):
-        """This is a top module."""
-
-        def __init__(self, width, **kwargs):
-            """:param width: The width of the module."""
-            super().__init__(**kwargs)
-            self.io += Input("a", width, description="Input A")
-            self.io += Output("b", width)
-            self.io.b <<= self.io.a
-
-    spec = Top(width=7086, name="TopLevel").spec
-    assert spec["name"] == "TopLevel"
-    assert spec["description"] == "This is a top module."
-    assert spec["parameters"][0]["name"] == "width"
-    assert spec["parameters"][0]["value"] == 7086
-    assert spec["parameters"][0]["description"] == "The width of the module."
-    for port in spec["ports"]:
-        assert port["name"] in ["a", "b"]
-        assert port["width"] == 7086
-        if port["name"] == "a":
-            assert port["direction"] == "INPUT"
-            assert port["description"] == "Input A"
-        else:
-            assert port["direction"] == "OUTPUT"
-            assert port["description"] == ""
+        spec = Top(width=7086, name="TopLevel").spec
+        assert spec["name"] == "TopLevel"
+        assert spec["description"] == "This is a top module."
+        assert spec["parameters"][0]["name"] == "width"
+        assert spec["parameters"][0]["value"] == 7086
+        assert spec["parameters"][0]["description"] == "The width of the module."
+        for port in spec["ports"]:
+            assert port["name"] in ["a", "b"]
+            assert port["width"] == 7086
+            if port["name"] == "a":
+                assert port["direction"] == "INPUT"
+                assert port["description"] == "Input A"
+            else:
+                assert port["direction"] == "OUTPUT"
+                assert port["description"] == ""
 
 
 def test_module_io_definition():


### PR DESCRIPTION
## Features / Changes
Bug Fix:  Missing signal declaration for the Signal connecting to the output port of an Instance

## Bug Reproduction
- How to reproduce the bug
  - Create a module with Input and Output
  - Instantiate with `NewModule.instance()` 
  - Connect some of the Outputs to other signals but not all.

- Expected behaviour
  All logic vectors connected to the Output Ports shall have signal declaration (i.e. `logic [...] net_abc`) with the instantiation
- Actual behaviour
  Signal declarations of the unused output are missing

## Testing
- Test cases added: `test_logic_decl_with_unused_output`
