### PR TITLE
Feature: Manual SVA

### DIFF
--- a/magia/data_struct.py
+++ b/magia/data_struct.py
@@ -56,6 +56,14 @@ class SignalType(Enum):
     CONSTANT = 4
 
 
+class PropType(Enum):
+    """Type of Properties."""
+
+    ASSERT = "assert"
+    ASSUME = "assume"
+    COVER = "cover"
+
+
 class OPType(IntEnum):
     """List of operations that can be performed on signals."""
 

--- a/magia/module.py
+++ b/magia/module.py
@@ -12,7 +12,8 @@ from typing import TYPE_CHECKING
 
 from .data_struct import SignalDict, SignalType
 from .io_ports import IOPorts
-from .memory import Memory, MemorySignal
+from .io_signal import Input, Output
+from .memory import MemorySignal
 from .signals import SIGNAL_ASSIGN_TEMPLATE, CodeSectionType, Signal, Synthesizable
 from .utils import ModuleContext
 
@@ -140,7 +141,7 @@ class Module(Synthesizable, metaclass=_ModuleMetaClass):
 
         mod_decl = self.mod_declaration()
 
-        signals, insts = self.trace()
+        signals, insts = self.trace(self.io.outputs)
 
         mod_impl = [
             inst.elaborate()
@@ -181,73 +182,89 @@ class Module(Synthesizable, metaclass=_ModuleMetaClass):
         _ = self  # Stub to avoid IDE/Lint warning
         return ""
 
-    def trace(self) -> tuple[list[Signal | Memory], list[Instance]]:
-        """Trace nets and instances from output ports."""
-        traced_sig_id: set[int] = set()
+    @staticmethod
+    def trace(trace_from: list[Synthesizable]) -> tuple[list[Synthesizable], list[Instance]]:
+        """Trace nets and instances from a set of synthesizable objects."""
+        traced_obj_id: set[int] = set()
         traced_inst_id: set[int] = set()
-        traced_signal: list[Signal | Memory] = []
+        traced_obj: list[Synthesizable] = []
         traced_inst: list[Instance] = []
-        sig_to_be_traced: dict[int, Signal] = {}
+        obj_to_be_traced: dict[int, Synthesizable] = {
+            id(obj): obj
+            for obj in trace_from
+        }
 
-        for output in self.io.outputs:
-            sig_to_be_traced |= {
-                id(sig): sig
-                for sig in output.drivers
-            }
-        while sig_to_be_traced:
+        while obj_to_be_traced:
             next_trace = {}
-            for signal_id, signal in sig_to_be_traced.items():
+            for obj_id, obj in obj_to_be_traced.items():
+                if obj_id in traced_obj_id:
+                    continue
+                if not isinstance(obj, (Input, Output)):
+                    traced_obj_id.add(obj_id)
+                    traced_obj.append(obj)
 
-                # Tracing Instances with Output connected
-                if signal.type == SignalType.OUTPUT:
-                    inst = signal.owner_instance
-                    if inst is not None and id(inst) not in traced_inst_id:
-                        traced_inst_id.add(id(inst))
-                        traced_inst.append(inst)
+                match obj:
+                    case Input():
+                        continue
 
-                        # Trace the IO Ports of an instance.
-                        # Input port is driven by external signal, so we go for the driver.
-                        # Output port is an extra signal placeholder,
-                        # so we add the port itself and ensure the declaration exists.
-                        port_drivers = [
-                            port.driver() if port.type == SignalType.INPUT else port
-                            for port in inst.io.values()
-                        ]
-                        next_trace |= {
-                            id_sig: sig
-                            for sig in port_drivers
-                            if (id_sig := id(sig)) not in traced_sig_id
-                        }
-                elif signal.type != SignalType.INPUT and signal_id not in traced_sig_id:
-                    traced_sig_id.add(signal_id)
-                    traced_signal.append(signal)
-
-                    next_trace |= {
-                        id_sig: sig
-                        for sig in signal.drivers
-                        if sig.type not in (SignalType.INPUT,)
-                           and (id_sig := id(sig)) not in traced_sig_id
-                    }
-
-                    if signal.type == SignalType.MEMORY:
-                        signal: MemorySignal
-                        if id(signal.memory) not in traced_sig_id:
-                            traced_sig_id.add(id(signal.memory))
-                            traced_signal.append(signal.memory)
-
+                    case Output():
+                        owner_inst = obj.owner_instance
+                        if owner_inst is None:
                             next_trace |= {
-                                id_sig: sig
-                                for sig in signal.memory.drivers
-                                if (id_sig := id(sig)) not in traced_sig_id
+                                id_sig: sig for sig in obj.drivers
+                                if (id_sig := id(sig)) not in traced_obj_id
+                            }
+                        else:
+                            if id(owner_inst) in traced_inst_id:
+                                continue
+                            traced_inst_id.add(id(owner_inst))
+                            traced_inst.append(owner_inst)
+                            # Trace the IO Ports of an instance.
+                            # Input port is driven by external signal, so we go for the driver.
+                            # Output port is an extra signal placeholder,
+                            # so we add the port itself and ensure the declaration exists.
+                            port_drivers = [
+                                port.driver() if port.type == SignalType.INPUT else port
+                                for port in owner_inst.io.values()
+                            ]
+                            next_trace |= {
+                                id_sig: sig for sig in port_drivers
+                                if (id_sig := id(sig)) not in traced_obj_id
                             }
 
-            sig_to_be_traced = next_trace
+                    case MemorySignal() as obj_mem_sig:
+                        next_trace |= {
+                            id_sig: sig for sig in obj_mem_sig.drivers
+                            if (id_sig := id(sig)) not in traced_obj_id
+                        }
 
-        traced_signal.reverse()
+                        obj_mem = obj_mem_sig.memory
+                        if id(obj_mem) in traced_obj_id:
+                            continue
+
+                        traced_obj_id.add(id(obj_mem))
+                        traced_obj.append(obj_mem)
+                        next_trace |= {
+                            id_sig: sig for sig in obj_mem.drivers
+                            if (id_sig := id(sig)) not in traced_obj_id
+                        }
+
+                    case Signal():
+                        next_trace |= {
+                            id_sig: sig for sig in obj.drivers
+                            if (id_sig := id(sig)) not in traced_obj_id
+                        }
+
+                    case _:
+                        raise ValueError(f"Unsupported object type: {obj}")
+
+            obj_to_be_traced = next_trace
+
+        traced_obj.reverse()
         traced_inst.reverse()
 
         # Check if we have name conflict on the signals and instances
-        sig_name_counter = Counter(sig.name for sig in traced_signal)
+        sig_name_counter = Counter(sig.name for sig in traced_obj)
         inst_name_counter = Counter(inst.name for inst in traced_inst)
         sig_conflicts = [name for name, cnt in sig_name_counter.items() if cnt > 1]
         inst_conflicts = [name for name, cnt in inst_name_counter.items() if cnt > 1]
@@ -256,7 +273,7 @@ class Module(Synthesizable, metaclass=_ModuleMetaClass):
         if inst_conflicts:
             raise ValueError(f"Instance name conflict: {inst_conflicts}")
 
-        return traced_signal, traced_inst
+        return traced_obj, traced_inst
 
     def instance(
             self, name: None | str = None,

--- a/magia/signals.py
+++ b/magia/signals.py
@@ -32,6 +32,7 @@ class CodeSectionType(Enum):
     LOGIC = auto()
     VERILOG = auto()
     FORMAL = auto()
+    SVA_MANUAL = auto()
 
 
 @dataclass
@@ -326,6 +327,8 @@ class Signal(Synthesizable):
                 template = SIGNAL_DECL_VERILOG_TEMPLATE
             case CodeSectionType.FORMAL:
                 template = SIGNAL_DECL_FORMAL_TEMPLATE
+            case CodeSectionType.SVA_MANUAL:
+                template = SIGNAL_DECL_TEMPLATE
 
         decl = template.substitute(
             signed="signed" if self.signed else "",

--- a/magia/sva_manual.py
+++ b/magia/sva_manual.py
@@ -31,8 +31,8 @@ class SVAManual(Synthesizable):
     assertion_count = 0
 
     def __init__(
-            self, prop_statement: str,
-            name: None | str, clk: Signal, disable_iff: None | Signal = None,
+            self, name: None | str, prop_statement: str, clk: Signal,
+            disable_iff: None | Signal = None,
             prop_type: PropType = PropType.ASSERT,
             **kwargs
     ):

--- a/magia/sva_manual.py
+++ b/magia/sva_manual.py
@@ -1,0 +1,77 @@
+from contextlib import contextmanager
+from string import Template
+
+from .data_struct import PropType
+from .signals import CodeSectionType, Signal, Synthesizable
+
+SVA_MANUAL_TEMPLATE = Template(
+    "$prop_name: $prop_type property (\n"
+    "  @(posedge $clk)\n"
+    "  $prop_statement\n"
+    ");\n"
+)
+SVA_MANUAL_DISABLE_IFF_TEMPLATE = Template(
+    "$prop_name: $prop_type property (\n"
+    "  @(posedge $clk) disable iff($disable_iff)\n"
+    "  $prop_statement\n"
+    ");\n"
+)
+
+
+class SVAManual(Synthesizable):
+    """Manual SystemVerilog Assertions statements."""
+
+    assertion_count = 0
+
+    def __init__(
+            self, prop_statement: str,
+            name: None | str, clk: Signal, disable_iff: None | Signal = None,
+            prop_type: PropType = PropType.ASSERT,
+            **kwargs
+    ):
+        super().__init__(**kwargs)
+        if name is None:
+            name = f"prop_{SVAManual.assertion_count}"
+            SVAManual.assertion_count += 1
+        self._name = f"{prop_type.value}_{name}"
+        self.prop_statement = prop_statement
+        self.clk = clk
+        self.disable_iff = disable_iff
+        self.prop_type = prop_type
+
+    @classmethod
+    @contextmanager
+    def code_section(cls):
+        """
+        Context manager for Manual SVA code section.
+
+        This code section activate `name_as_str` context, which allows developer use f-string
+        referring to the signal name.
+
+        e.g. f"{req} |=> {valid}"
+        """
+        with Synthesizable.code_section(CodeSectionType.SVA_MANUAL), Signal.name_as_str():
+            yield
+
+    @property
+    def drivers(self) -> list[Signal]:
+        """Return the clock domain driving signals of the assertion."""
+        if self.disable_iff is not None:
+            return [self.clk, self.disable_iff]
+        return [self.clk]
+
+    @property
+    def name(self) -> str:
+        """Return the name of the assertion."""
+        return self._name
+
+    def elaborate(self) -> str:
+        """Elaborate the SystemVerilog assertion statement."""
+        template = SVA_MANUAL_TEMPLATE if self.disable_iff is None else SVA_MANUAL_DISABLE_IFF_TEMPLATE
+        return template.substitute(
+            prop_name=self.name,
+            prop_type=self.prop_type.value,
+            clk=self.clk.name,
+            disable_iff=self.disable_iff.name if self.disable_iff is not None else "",
+            prop_statement=self.prop_statement
+        )

--- a/magia/sva_manual.py
+++ b/magia/sva_manual.py
@@ -1,8 +1,15 @@
+"""
+Manual SystemVerilog Assertions statements.
+
+It is used to create SystemVerilog assertions that are not supported by the magia library.
+We assume the developer has the knowledge of SystemVerilog Assertions and can write the assertions manually.
+"""
 from contextlib import contextmanager
 from string import Template
 
 from .data_struct import PropType
 from .signals import CodeSectionType, Signal, Synthesizable
+from .utils import ModuleContext
 
 SVA_MANUAL_TEMPLATE = Template(
     "$prop_name: $prop_type property (\n"
@@ -30,6 +37,9 @@ class SVAManual(Synthesizable):
             **kwargs
     ):
         super().__init__(**kwargs)
+        if (module_context := ModuleContext().current) is not None:
+            module_context.manual_sva_collected.append(self)
+
         if name is None:
             name = f"prop_{SVAManual.assertion_count}"
             SVAManual.assertion_count += 1

--- a/tests/helper/__init__.py
+++ b/tests/helper/__init__.py
@@ -45,10 +45,15 @@ def simulate(
         test_module: str | Sequence[str],
         python_search_path: str | Sequence[str] | None = None,
         testcase: str | Sequence[str] | None = None,
+        build_args: str | Sequence[str] | None = None,
 ):
     sim = Simulator(top_level_name)
     sim.add_magia_module(hdl_modules)
-    sim.compile()
+    sim.compile(**(
+        {
+            "build_args": build_args,
+        } if build_args is not None else {}
+    ))
     sim.sim(
         testcase=testcase,
         test_module=test_module,

--- a/tests/test_sva_manual.py
+++ b/tests/test_sva_manual.py
@@ -2,7 +2,7 @@ import cocotb
 import pytest
 from cocotb.clock import Clock
 from cocotb.triggers import FallingEdge
-from magia_flow.simulation import Simulator
+from magia_flow.simulation.general import Simulator
 
 from magia import Input, Module, Output, Register
 from magia.sva_manual import SVAManual

--- a/tests/test_sva_manual.py
+++ b/tests/test_sva_manual.py
@@ -1,0 +1,66 @@
+import cocotb
+import pytest
+from cocotb.clock import Clock
+from cocotb.triggers import FallingEdge
+from magia_flow.simulation import Simulator
+
+from magia import Input, Module, Output, Register
+from magia.sva_manual import SVAManual
+from tests.helper import simulate
+
+
+@cocotb.test()
+async def counter_test(dut):
+    clock = Clock(dut.clk, 10, units="ns")
+    cocotb.start_soon(clock.start())
+
+    dut.rst.value = 1
+    await FallingEdge(dut.clk)
+    await FallingEdge(dut.clk)
+
+    dut.rst.value = 0
+
+    for _ in range(1000):
+        await FallingEdge(dut.clk)
+
+
+class TestSVAManual:
+    TOP = "Counter"
+    sim_module_and_path = {
+        "test_module": [Simulator.current_package()],
+        "python_search_path": [Simulator.current_dir()],
+    }
+
+    class Counter(Module):
+        def __init__(self, sva_fail=False, **kwargs):
+            super().__init__(**kwargs)
+            self.io += [
+                Input("clk", 1),
+                Input("rst", 1),
+                Output("out", 8),
+            ]
+
+            clk = {"clk": self.io.clk}
+
+            counter = Register(8, **clk)
+            counter <<= (counter + 1).when(self.io.rst == 0, 0)
+            self.io.out <<= counter
+
+            with SVAManual.code_section():
+                SVAManual(
+                    f"{self.io.out == 10} |=> {self.io.out == (12 if sva_fail else 11)}",
+                    name="count", **clk,
+                )
+
+    def test_assertion_success(self):
+        simulate(
+            self.TOP, self.Counter(name=self.TOP), testcase="counter_test",
+            build_args=["--assert"], **self.sim_module_and_path,
+        )
+
+    def test_assertion_failed(self):
+        with pytest.raises(SystemExit):
+            simulate(
+                self.TOP, self.Counter(name=self.TOP, sva_fail=True), testcase="counter_test",
+                build_args=["--assert"], **self.sim_module_and_path,
+            )

--- a/tests/test_sva_manual.py
+++ b/tests/test_sva_manual.py
@@ -48,8 +48,9 @@ class TestSVAManual:
 
             with SVAManual.code_section():
                 SVAManual(
+                    "count_10_to_11" if not sva_fail else "count_10_to_12_shall_fail",
                     f"{self.io.out == 10} |=> {self.io.out == (12 if sva_fail else 11)}",
-                    name="count", **clk,
+                    **clk,
                 )
 
     def test_assertion_success(self):


### PR DESCRIPTION
## Features / Changes

- Adding `SVAManual` which inserts SVA statements into the elaborated code
- Adding `SVAManual.code_section()` which
  - Auto resolve signal net name in a f-string, instead of calling `Signal.name`
  - `SVAManual` and `Signal` within the code section will be auto and elaborated, even if they do not drive an output pin

### Sample Code
```python
class Top(Module):
    def __init__(...):
        ...
        with SVAManual.code_section():
            SVAManual(
                "count_10_to_11",
                f"{self.io.out == 10} |=> {self.io.out == 11}",
                clk=self.io.clk,
            )
```

## Testing

- Testcase added: `test_sva_manual.py`
  Checking if the Manual SVAs inserted are functional in Verilator

## Follow-up

- [ ] Providing document on the usage
