### PR TITLE
Fix: Signal Declaration at the beginning of Elaborated Module

### DIFF
--- a/magia/comb_ops.py
+++ b/magia/comb_ops.py
@@ -110,7 +110,6 @@ class Operation(Signal):
 
     def elaborate(self) -> str:
         """Declare the signal and elaborate the operation in the module implementation."""
-        signal_decl = self.signal_decl()
         op_impl = ""
         if self.signal_config.op_type in OP_IMPL_TEMPLATE:
             impl_params = {
@@ -133,7 +132,7 @@ class Operation(Signal):
             op_impl = OP_IMPL_TEMPLATE[self.signal_config.op_type].substitute(**impl_params)
             op_impl = OP_BLOCK_TEMPLATE.substitute(op_impl=op_impl)
 
-        return "\n".join((signal_decl, op_impl))
+        return op_impl
 
     @staticmethod
     def create(op_type: OPType, x: Signal, y: None | Signal | slice | int | bytes) -> Operation:

--- a/magia/comb_select.py
+++ b/magia/comb_select.py
@@ -52,14 +52,12 @@ class When(Signal):
         self._drivers["d_false"] = if_false
 
     def elaborate(self) -> str:
-        signal_decl = self.signal_decl()
-        if_else = IF_ELSE_TEMPLATE.substitute(
+        return IF_ELSE_TEMPLATE.substitute(
             output=self.name,
             condition=self._drivers["condition"].name,
             if_true=self._drivers[self.DEFAULT_DRIVER].name,
             if_false=self._drivers["d_false"].name,
         )
-        return "\n".join((signal_decl, if_else))
 
 
 class Case(Signal):
@@ -136,7 +134,6 @@ class Case(Signal):
                 return sig_or_const.name
             return Constant.sv_constant(sig_or_const, self.width, self.signed)
 
-        signal_decl = self.signal_decl()
         case_table = []
 
         for selector_value, driver in self._cases.items():
@@ -162,9 +159,8 @@ class Case(Signal):
                 )
             )
 
-        case_impl = CASE_TEMPLATE.substitute(
+        return CASE_TEMPLATE.substitute(
             selector=self._drivers[self.DEFAULT_DRIVER].name,
             cases="\n".join(case_table),
             unique="unique" if self._case_config.unique else "",
         )
-        return "\n".join((signal_decl, case_impl))

--- a/magia/constant.py
+++ b/magia/constant.py
@@ -31,12 +31,10 @@ class Constant(Signal):
         self.value = value
 
     def elaborate(self) -> str:
-        signal_decl = self.signal_decl()
-        assignment = SIGNAL_ASSIGN_TEMPLATE.substitute(
+        return SIGNAL_ASSIGN_TEMPLATE.substitute(
             name=self.name,
             driver=self.sv_constant(self.value, self.width, self.signed),
         )
-        return "\n".join((signal_decl, assignment))
 
     @staticmethod
     def sv_constant(value: None | int | bytes, width: int, signed: bool = False) -> str:

--- a/magia/memory.py
+++ b/magia/memory.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from itertools import count
 
 from .data_struct import SignalDict, SignalType
-from .io_signal import Input, Output
+from .io_signal import Input
 from .signals import Signal, Synthesizable
 
 
@@ -28,16 +28,8 @@ class MemorySignal(Signal):
     def __init__(self, memory: Memory, name: str, width: int, drive_by_mem: bool = False, **kwargs):
         super().__init__(name=name, width=width, **kwargs)
         self.signal_config.signal_type = SignalType.MEMORY
-        self._memory = memory
-        self._drive_by_mem = drive_by_mem
-
-    @property
-    def memory(self) -> Memory:
-        return self._memory
-
-    @property
-    def drive_by_mem(self) -> bool:
-        return self._drive_by_mem
+        self.memory = memory
+        self.drive_by_mem = drive_by_mem
 
     @property
     def drivers(self) -> list[Signal]:
@@ -54,7 +46,7 @@ class MemorySignal(Signal):
         :returns: The driver signal.
         """
         if self.drive_by_mem:
-            return Output("dummy", 1)
+            return None
         return self._drivers.get(driver_name)
 
 

--- a/magia/register.py
+++ b/magia/register.py
@@ -160,8 +160,6 @@ class Register(Signal):
         if errors:
             raise ValueError(f"Register {self.name} is not valid.", errors)
 
-        reg_decl = self.signal_decl()
-
         match self._reg_config.enable, self._reg_config.reset, self._reg_config.async_reset:
             case (False, False, False):
                 reg_type = RegType.DFF
@@ -197,6 +195,4 @@ class Register(Signal):
                 self._reg_config.async_reset_value, self.width, self.signed
             )
 
-        reg_impl = REG_TEMPLATE[reg_type].substitute(**connections)
-
-        return "\n".join((reg_decl, reg_impl))
+        return REG_TEMPLATE[reg_type].substitute(**connections)

--- a/magia/signals.py
+++ b/magia/signals.py
@@ -366,14 +366,16 @@ class Signal(Synthesizable):
     def elaborate(self) -> str:
         signal_decl = self.signal_decl()
 
-        # Ignore assignment signal if it is driven by an output of a module instance
-        if self.driver().type != SignalType.OUTPUT:
-            assignment = SIGNAL_ASSIGN_TEMPLATE.substitute(
-                name=self.name,
-                driver=self.driver().name,
-            )
-            return "\n".join((signal_decl, assignment))
-        return signal_decl
+        # Ignore assignment signal if it is not driven by any signal
+        # or by an output of a module instance
+        if (driving_signal := self.driver()) is None or driving_signal.owner_instance is not None:
+            return signal_decl
+
+        assignment = SIGNAL_ASSIGN_TEMPLATE.substitute(
+            name=self.name,
+            driver=self.driver().name,
+        )
+        return "\n".join((signal_decl, assignment))
 
     def __ilshift__(self, other):
         """

--- a/magia/signals.py
+++ b/magia/signals.py
@@ -364,18 +364,15 @@ class Signal(Synthesizable):
         return repr(self)
 
     def elaborate(self) -> str:
-        signal_decl = self.signal_decl()
-
         # Ignore assignment signal if it is not driven by any signal
         # or by an output of a module instance
         if (driving_signal := self.driver()) is None or driving_signal.owner_instance is not None:
-            return signal_decl
+            return ""
 
-        assignment = SIGNAL_ASSIGN_TEMPLATE.substitute(
+        return SIGNAL_ASSIGN_TEMPLATE.substitute(
             name=self.name,
             driver=self.driver().name,
         )
-        return "\n".join((signal_decl, assignment))
 
     def __ilshift__(self, other):
         """

--- a/tests/core/test_signal.py
+++ b/tests/core/test_signal.py
@@ -87,7 +87,7 @@ class TestSignalManipulate:
         """Signal can be annotated by `signal.annotate()` with comment."""
         signal = Signal(8, name="a").annotate("This is a comment")
         signal <<= signal  # Stub just for elaboration
-        result = signal.elaborate()
+        result = f"{signal.signal_decl()}\n{signal.elaborate()}"
         assert "/*" in result, "There shall be a comment in the elaboration result"
         assert "Net name: a\nThis is a comment\n/" in result, "Net name does not exists in the elaboration result"
         assert __file__ in result, "The file name does not exists in the elaboration result"
@@ -96,7 +96,7 @@ class TestSignalManipulate:
         """Signal can be annotated by `signal.annotate()` without comment."""
         signal = Signal(8, name="a").annotate()
         signal <<= signal  # Stub just for elaboration
-        result = signal.elaborate()
+        result = f"{signal.signal_decl()}\n{signal.elaborate()}"
         assert "/*" in result, "There shall be a comment in the elaboration result"
         assert "Net name: a\n/" in result, "Net name does not exists in the elaboration result"
         assert __file__ in result, "The file name does not exists in the elaboration result"


### PR DESCRIPTION
## Features / Changes

- Fix: Separate the Signal Declaration and Logic implementation, and put the declaration at the beginning

## Bug Reproduction

- How to reproduce the bug?
Create a simple design with some internal logic + feedback loops (e.g. counter)
Elaborate the code and run it on VCS [e.g. on EDA Playground](https://www.edaplayground.com/)

- Expected behaviour
The code can be compiled and simulated without warning

- Actual behaviour
`Warning-[IPDW] Identifier previously declared` is produced by VCS. Some simulators even produce errors.
Verilator is, in fact, the only simulator that accepts postponed signal declaration we can access.

## Testing

- Existing Test cases passed
- All commercial simulators compiled and simulated a counter design successfully, without warning.
