### PR TITLE
Refactor: Deprecate SignalType Enum

### DIFF
--- a/magia/bundle.py
+++ b/magia/bundle.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import enum
 
-from .data_struct import SignalDict, SignalType
+from .data_struct import SignalDict
 from .io_ports import IOPorts
 from .io_signal import Input, Output
 from .module import Instance
@@ -293,18 +293,18 @@ class Bundle:
             # IO ports owned by instance
             # Inputs are load, outputs are drivers
             for src_name, dst_name in connection_map.items():
-                match mod_io[dst_name].type:
-                    case SignalType.INPUT:
+                match mod_io[dst_name]:
+                    case Input():
                         target_io.io[dst_name] <<= self[src_name]
-                    case SignalType.OUTPUT:
+                    case Output():
                         self[src_name] <<= target_io.io[dst_name]
 
         else:
             # IO ports owned by module
             # Inputs are drivers, outputs are loads
             for src_name, dst_name in connection_map.items():
-                match target_io[dst_name].type:
-                    case SignalType.INPUT:
+                match target_io[dst_name]:
+                    case Input():
                         self[src_name] <<= target_io[dst_name]
-                    case SignalType.OUTPUT:
+                    case Output():
                         target_io[dst_name] <<= self[src_name]

--- a/magia/comb_ops.py
+++ b/magia/comb_ops.py
@@ -138,7 +138,7 @@ class Operation(Signal):
     def create(op_type: OPType, x: Signal, y: None | Signal | slice | int | bytes) -> Operation:
         """Create common operation with single / two arguments."""
         if not isinstance(x, Signal):
-            raise TypeError(f"Cannot perform operation on {type(x)}")
+            raise TypeError(f"Cannot perform operation on {type(x).__name__}")
 
         if op_type not in OP_IMPL_TEMPLATE:
             raise ValueError(f"Operation {op_type} is not supported.")
@@ -155,7 +155,7 @@ class Operation(Signal):
             if isinstance(y, (int, bytes)):
                 y = Constant(y, x.width, x.signed)
             if not isinstance(y, Signal) and y is not None:
-                raise TypeError(f"Cannot perform operation on {type(y)}")
+                raise TypeError(f"Cannot perform operation on {type(y).__name__}")
 
         # Check the Sign of the Operands
         if op_type in (

--- a/magia/constant.py
+++ b/magia/constant.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 from itertools import count
 from math import ceil
 
-from .data_struct import SignalType
 from .signals import SIGNAL_ASSIGN_TEMPLATE, Signal
 
 
@@ -27,7 +26,6 @@ class Constant(Signal):
             name = f"const_{next(self.new_const_counter)}"
 
         super().__init__(width=width, signed=signed, name=name, **kwargs)
-        self.signal_config.signal_type = SignalType.CONSTANT
         self.value = value
 
     def elaborate(self) -> str:

--- a/magia/constant.py
+++ b/magia/constant.py
@@ -58,3 +58,6 @@ class Constant(Signal):
             value = "X"
         sign = "s" if signed else ""
         return f"{width}'{sign}h{value}"
+
+    def __ilshift__(self, other):
+        raise ValueError("Cannot drive output of a module instance.")

--- a/magia/data_struct.py
+++ b/magia/data_struct.py
@@ -46,16 +46,6 @@ class SignalDict(UserDict):
             self.data[alias] = value
 
 
-class SignalType(Enum):
-    """Kinds of signals."""
-
-    SIGNAL = 0
-    INPUT = 1
-    OUTPUT = 2
-    MEMORY = 3
-    CONSTANT = 4
-
-
 class PropType(Enum):
     """Type of Properties."""
 

--- a/magia/factory.py
+++ b/magia/factory.py
@@ -27,6 +27,22 @@ def constant_like(value: int | bytes, signal: Signal) -> Constant:
     return constant(value, signal.width, signal.signed)
 
 
+def signal_config_like(signal: Signal, **kwargs) -> dict:
+    """
+    Create a signal configuration dictionary with the same configuration as the given signal.
+
+    Bundle information and Module instances are not copied.
+    """
+    return {
+        "name": signal.name,
+        "width": signal.width,
+        "signed": signal.signed,
+        "description": signal.description,
+        "signal_type": signal.type,
+        **kwargs,
+    }
+
+
 def sv_constant(value: None | int | bytes, width: int, signed: bool = False) -> str:
     """Redirect call to Constant.sv_constant, create SystemVerilog constant expression."""
     return Constant.sv_constant(value, width, signed)

--- a/magia/factory.py
+++ b/magia/factory.py
@@ -38,7 +38,6 @@ def signal_config_like(signal: Signal, **kwargs) -> dict:
         "width": signal.width,
         "signed": signal.signed,
         "description": signal.description,
-        "signal_type": signal.type,
         **kwargs,
     }
 

--- a/magia/io_ports.py
+++ b/magia/io_ports.py
@@ -47,7 +47,7 @@ class IOPorts:
         else:
             if isinstance(other, IOPorts):
                 other = other.inputs + other.outputs
-            elif isinstance(other, (Input, Output)):
+            elif other.is_input or other.is_output:
                 other = [other]
 
         for port in other:
@@ -60,7 +60,7 @@ class IOPorts:
         if port.name in self.signals:
             raise KeyError(f"Port {port.name} is already defined.")
 
-        if not isinstance(port, (Input, Output)):
+        if not port.is_input and not port.is_output:
             raise TypeError(f"Signal Type {type(port)} is forbidden in IOPorts.")
 
         self.signals[port.name] = port.__class__(
@@ -97,28 +97,28 @@ class IOPorts:
     def inputs(self) -> list[Signal]:
         return [
             signal for signal in self.signals.values()
-            if isinstance(signal, Input)
+            if signal.is_input
         ]
 
     @property
     def outputs(self) -> list[Signal]:
         return [
             signal for signal in self.signals.values()
-            if isinstance(signal, Output)
+            if signal.is_output
         ]
 
     @property
     def input_names(self) -> list[str]:
         return [
             name for name, port in self.signals.items()
-            if isinstance(port, Input)
+            if port.is_input
         ]
 
     @property
     def output_names(self) -> list[str]:
         return [
             name for name, port in self.signals.items()
-            if isinstance(port, Output)
+            if port.is_output
         ]
 
     def __ilshift__(self, other: Bundle):

--- a/magia/io_ports.py
+++ b/magia/io_ports.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import typing
 from dataclasses import asdict
 
-from .data_struct import SignalDict, SignalType
+from .data_struct import SignalDict
 from .io_signal import Input, Output
 from .signals import Signal
 
@@ -60,8 +60,8 @@ class IOPorts:
         if port.name in self.signals:
             raise KeyError(f"Port {port.name} is already defined.")
 
-        if port.type not in (SignalType.INPUT, SignalType.OUTPUT):
-            raise TypeError(f"Signal Type {port.type} is forbidden in IOPorts.")
+        if not isinstance(port, (Input, Output)):
+            raise TypeError(f"Signal Type {type(port)} is forbidden in IOPorts.")
 
         self.signals[port.name] = port.__class__(
             **{
@@ -97,28 +97,28 @@ class IOPorts:
     def inputs(self) -> list[Signal]:
         return [
             signal for signal in self.signals.values()
-            if signal.type == SignalType.INPUT
+            if isinstance(signal, Input)
         ]
 
     @property
     def outputs(self) -> list[Signal]:
         return [
             signal for signal in self.signals.values()
-            if signal.type == SignalType.OUTPUT
+            if isinstance(signal, Output)
         ]
 
     @property
     def input_names(self) -> list[str]:
         return [
             name for name, port in self.signals.items()
-            if port.type == SignalType.INPUT
+            if isinstance(port, Input)
         ]
 
     @property
     def output_names(self) -> list[str]:
         return [
             name for name, port in self.signals.items()
-            if port.type == SignalType.OUTPUT
+            if isinstance(port, Output)
         ]
 
     def __ilshift__(self, other: Bundle):

--- a/magia/io_signal.py
+++ b/magia/io_signal.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from .data_struct import SignalType
+from .factory import signal_config_like
 from .signals import Signal
 
 if TYPE_CHECKING:
@@ -52,6 +53,11 @@ class Input(Signal):
             raise ValueError("Cannot drive the Input of a module type.")
         return super().__ilshift__(other)
 
+    @classmethod
+    def like(cls, signal: Signal, **kwargs) -> Signal:
+        """Create an Input with the same configuration as the given signal."""
+        return Input(**signal_config_like(signal, **kwargs))
+
 
 class Output(Signal):
     """
@@ -94,3 +100,8 @@ class Output(Signal):
         if self.owner_instance is not None:
             raise ValueError("Cannot drive output of a module instance.")
         return super().__ilshift__(other)
+
+    @classmethod
+    def like(cls, signal: Signal, **kwargs) -> Signal:
+        """Create an output with the same configuration as the given signal."""
+        return Output(**signal_config_like(signal, **kwargs))

--- a/magia/io_signal.py
+++ b/magia/io_signal.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .data_struct import SignalType
 from .factory import signal_config_like
 from .signals import Signal
 
@@ -31,7 +30,6 @@ class Input(Signal):
             raise ValueError("Input width is not set")
 
         super().__init__(name=name, width=width, signed=signed, **kwargs)
-        self.signal_config.signal_type = SignalType.INPUT
         self.signal_config.owner_instance = owner_instance
 
     @property
@@ -79,7 +77,6 @@ class Output(Signal):
         if width == 0:
             raise ValueError("Output width is not set")
         super().__init__(name=name, width=width, signed=signed, **kwargs)
-        self.signal_config.signal_type = SignalType.OUTPUT
         self.signal_config.owner_instance = owner_instance
 
     @property

--- a/magia/io_signal.py
+++ b/magia/io_signal.py
@@ -33,6 +33,11 @@ class Input(Signal):
         self.signal_config.signal_type = SignalType.INPUT
         self.signal_config.owner_instance = owner_instance
 
+    @property
+    def is_input(self) -> bool:
+        """Check if the signal is an input signal."""
+        return True
+
     def elaborate(self) -> str:
         """
         Elaborate the input signal in the module declaration.
@@ -41,6 +46,11 @@ class Input(Signal):
         """
         port_decl = self.signal_decl().rstrip(";")
         return f"input  {port_decl}"
+
+    def __ilshift__(self, other):
+        if self.owner_instance is None:
+            raise ValueError("Cannot drive the Input of a module type.")
+        return super().__ilshift__(other)
 
 
 class Output(Signal):
@@ -66,6 +76,11 @@ class Output(Signal):
         self.signal_config.signal_type = SignalType.OUTPUT
         self.signal_config.owner_instance = owner_instance
 
+    @property
+    def is_output(self) -> bool:
+        """Check if the signal is an output signal."""
+        return True
+
     def elaborate(self) -> str:
         """
         Elaborate the output signal in the module declaration.
@@ -74,3 +89,8 @@ class Output(Signal):
         """
         port_decl = self.signal_decl().rstrip(";")
         return f"output {port_decl}"
+
+    def __ilshift__(self, other):
+        if self.owner_instance is not None:
+            raise ValueError("Cannot drive output of a module instance.")
+        return super().__ilshift__(other)

--- a/magia/memory.py
+++ b/magia/memory.py
@@ -5,7 +5,7 @@ import string
 from dataclasses import dataclass
 from itertools import count
 
-from .data_struct import SignalDict, SignalType
+from .data_struct import SignalDict
 from .io_signal import Input
 from .signals import Signal, Synthesizable
 
@@ -27,7 +27,6 @@ class MemorySignal(Signal):
 
     def __init__(self, memory: Memory, name: str, width: int, drive_by_mem: bool = False, **kwargs):
         super().__init__(name=name, width=width, **kwargs)
-        self.signal_config.signal_type = SignalType.MEMORY
         self.memory = memory
         self.drive_by_mem = drive_by_mem
 

--- a/magia/module.py
+++ b/magia/module.py
@@ -10,7 +10,7 @@ from os import PathLike
 from string import Template
 from typing import TYPE_CHECKING
 
-from .data_struct import SignalDict, SignalType
+from .data_struct import SignalDict
 from .io_ports import IOPorts
 from .io_signal import Input, Output
 from .memory import MemorySignal
@@ -242,7 +242,7 @@ class Module(Synthesizable, metaclass=_ModuleMetaClass):
                             # Output port is an extra signal placeholder,
                             # so we add the port itself and ensure the declaration exists.
                             port_drivers = [
-                                port.driver() if port.type == SignalType.INPUT else port
+                                port.driver() if isinstance(port, Input) else port
                                 for port in owner_inst.io.values()
                             ]
                             next_trace |= {
@@ -389,7 +389,7 @@ class Module(Synthesizable, metaclass=_ModuleMetaClass):
             "ports": [
                 {
                     "name": alias,
-                    "direction": signal.type.name,
+                    "direction": type(signal).__name__,
                     "width": signal.width,
                     "signed": signal.signed,
                     "description": signal.description,
@@ -421,10 +421,10 @@ class Instance(Synthesizable):
         self.io = SignalDict()
 
         for port_name, port in self._io_ports.signals.items():
-            match port.type:
-                case SignalType.INPUT:
+            match port:
+                case Input():
                     self.io[port_name] = port
-                case SignalType.OUTPUT:
+                case Output():
                     self.io[port_name] = Signal(
                         width=port.width,
                         signed=port.signed,
@@ -433,10 +433,10 @@ class Instance(Synthesizable):
 
         if io is not None:
             for name, signal in io.items():
-                match signal.type:
-                    case SignalType.INPUT:
+                match signal:
+                    case Input():
                         self.io[name] <<= signal
-                    case SignalType.OUTPUT:
+                    case Output():
                         signal <<= self.io[name]
 
     @property
@@ -458,13 +458,13 @@ class Instance(Synthesizable):
     def validate(self) -> list[Exception]:
         errors = []
         for signal in self.io.values():
-            if signal.type == SignalType.INPUT and signal.driver() is None:
+            if isinstance(signal, Input) and signal.driver() is None:
                 errors.append(ValueError(f"Input {signal.name} is not connected."))
         return errors
 
     def _fix_output_name(self):
         for port, signal in self.io.items():
-            if signal.type != SignalType.INPUT and signal.name is None:
+            if isinstance(signal, Output) and signal.name is None:
                 signal.set_name(f"{self._inst_config.name}_output_{port}")
 
     def elaborate(self) -> str:
@@ -479,7 +479,7 @@ class Instance(Synthesizable):
         io_list = []
         for port_name, port in self._io_ports.signals.items():
             signal_name = self.io[port_name].name
-            if port.type == SignalType.INPUT:
+            if isinstance(port, Input):
                 signal_name = port.driver().name
 
             io_list.append(IO_TEMPLATE.substitute(port_name=port_name, signal_name=signal_name))

--- a/magia/signals.py
+++ b/magia/signals.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from string import Template
 from typing import TYPE_CHECKING
 
-from .data_struct import OPType, SignalDict, SignalType
+from .data_struct import OPType, SignalDict
 from .factory import constant, constant_like, create_case, create_comb_op, create_when, register, signal_config_like
 from .utils import ModuleContext
 
@@ -42,7 +42,6 @@ class SignalConfig:
     name: None | str = None
     width: int = 0
     signed: bool = False
-    signal_type: SignalType = SignalType.SIGNAL
     op_type: OPType = OPType.WIRE
     description: str = ""
 
@@ -220,10 +219,6 @@ class Signal(Synthesizable):
     def description(self) -> str:
         """Description of the signal."""
         return self.signal_config.description
-
-    @property
-    def type(self) -> SignalType:
-        return self.signal_config.signal_type
 
     @property
     def is_input(self) -> bool:

--- a/magia/signals.py
+++ b/magia/signals.py
@@ -12,7 +12,7 @@ from string import Template
 from typing import TYPE_CHECKING
 
 from .data_struct import OPType, SignalDict, SignalType
-from .factory import constant, constant_like, create_case, create_comb_op, create_when, register
+from .factory import constant, constant_like, create_case, create_comb_op, create_when, register, signal_config_like
 from .utils import ModuleContext
 
 if TYPE_CHECKING:
@@ -394,7 +394,7 @@ class Signal(Synthesizable):
         if isinstance(other, (int, bytes)):
             other = constant_like(other, self)
         if not isinstance(other, Signal):
-            raise TypeError(f"Cannot assign {type(other)} to drive {type(self)}")
+            raise TypeError(f"Cannot assign {type(other).__name__} to drive {type(self).__name__}")
         if self.driver() is not None:
             raise ValueError(f"Multiple driver on Signal {self.name}.")
 
@@ -530,7 +530,7 @@ class Signal(Synthesizable):
             item = slice(None, None, None)
 
         if not isinstance(item, slice):
-            raise TypeError(f"Cannot perform operation on {type(item)}")
+            raise TypeError(f"Cannot perform operation on {type(item).__name__}")
         if item.step is not None:
             raise ValueError("Slice step is not implement.")
 
@@ -544,7 +544,7 @@ class Signal(Synthesizable):
         """
         if isinstance(other, Signal):
             return create_comb_op(OPType.CONCAT, self, other)
-        raise TypeError(f"Cannot perform operation on {type(other)}")
+        raise TypeError(f"Cannot perform operation on {type(other).__name__}")
 
     def __imatmul__(self, other) -> Signal:
         return self.__matmul__(other)
@@ -609,3 +609,8 @@ class Signal(Synthesizable):
     def parity(self) -> Signal:
         """Create an `parity` statement."""
         return create_comb_op(OPType.PARITY, self, None)
+
+    @classmethod
+    def like(cls, signal: Signal, **kwargs) -> Signal:
+        """Create a signal with the same configuration as the given signal."""
+        return Signal(**signal_config_like(signal, **kwargs))

--- a/magia/signals.py
+++ b/magia/signals.py
@@ -226,6 +226,16 @@ class Signal(Synthesizable):
         return self.signal_config.signal_type
 
     @property
+    def is_input(self) -> bool:
+        """Check if the signal is an input signal."""
+        return False
+
+    @property
+    def is_output(self) -> bool:
+        """Check if the signal is an output signal."""
+        return False
+
+    @property
     def width(self):
         return self.signal_config.width
 
@@ -385,18 +395,13 @@ class Signal(Synthesizable):
             other = constant_like(other, self)
         if not isinstance(other, Signal):
             raise TypeError(f"Cannot assign {type(other)} to drive {type(self)}")
-        if self._drivers.get(self.DEFAULT_DRIVER) is not None:
+        if self.driver() is not None:
             raise ValueError(f"Multiple driver on Signal {self.name}.")
-        if self.type == SignalType.OUTPUT and self.owner_instance is not None:
-            raise ValueError("Cannot drive output of a module instance.")
-        if other.type == SignalType.INPUT and other.owner_instance is not None:
+
+        if other.is_input and other.owner_instance is not None:
             raise ValueError("Input of a module instance cannot drive other signal.")
-        if self.type == SignalType.INPUT and self.owner_instance is None:
-            raise ValueError("Cannot drive the Input of a module type.")
-        if other.type == SignalType.OUTPUT and other.owner_instance is None:
+        if other.is_output and other.owner_instance is None:
             raise ValueError("Output of a module type cannot drive other signal.")
-        if self.type == SignalType.CONSTANT:
-            raise ValueError("Constant signal cannot be driven.")
 
         self._drivers[self.DEFAULT_DRIVER] = other
         if self.width == 0:

--- a/tests/bus/test_axilite.py
+++ b/tests/bus/test_axilite.py
@@ -1,5 +1,5 @@
+from magia import Input, Output
 from magia.bus.axilite import axi4lite
-from magia.data_struct import SignalType
 
 
 class TestAXI4Lite:
@@ -8,32 +8,32 @@ class TestAXI4Lite:
     def test_master_direction(self):
         master_ports = self.spec.master_ports()
         for ports, direction in [
-            (("aclk", "aresetn",), SignalType.INPUT),
-            (("awready", "arready", "rdata", "rresp", "rvalid", "wready", "bresp", "bvalid",), SignalType.INPUT),
+            (("aclk", "aresetn",), Input),
+            (("awready", "arready", "rdata", "rresp", "rvalid", "wready", "bresp", "bvalid",), Input),
             (("awaddr", "awprot", "awvalid", "araddr", "arprot", "arvalid", "rready", "wdata", "wstrb", "wvalid",
-              "bready",), SignalType.OUTPUT),
+              "bready",), Output),
         ]:
             for port in ports:
-                assert master_ports[port].type == direction
+                assert isinstance(master_ports[port], direction)
 
     def test_slave_direction(self):
         slave_ports = self.spec.slave_ports()
         for ports, direction in [
-            (("aclk", "aresetn",), SignalType.INPUT),
-            (("awready", "arready", "rdata", "rresp", "rvalid", "wready", "bresp", "bvalid",), SignalType.OUTPUT),
+            (("aclk", "aresetn",), Input),
+            (("awready", "arready", "rdata", "rresp", "rvalid", "wready", "bresp", "bvalid",), Output),
             (("awaddr", "awprot", "awvalid", "araddr", "arprot", "arvalid", "rready", "wdata", "wstrb", "wvalid",
-              "bready",), SignalType.INPUT),
+              "bready",), Input),
         ]:
             for port in ports:
-                assert slave_ports[port].type == direction
+                assert isinstance(slave_ports[port], direction)
 
     def test_monitor_directions(self):
         monitor = self.spec.monitor_ports()
         for ports, direction in [
-            (("aclk", "aresetn",), SignalType.INPUT),
-            (("awready", "arready", "rdata", "rresp", "rvalid", "wready", "bresp", "bvalid",), SignalType.INPUT),
+            (("aclk", "aresetn",), Input),
+            (("awready", "arready", "rdata", "rresp", "rvalid", "wready", "bresp", "bvalid",), Input),
             (("awaddr", "awprot", "awvalid", "araddr", "arprot", "arvalid", "rready", "wdata", "wstrb", "wvalid",
-              "bready",), SignalType.INPUT),
+              "bready",), Input),
         ]:
             for port in ports:
-                assert monitor[port].type == direction
+                assert isinstance(monitor[port], direction)

--- a/tests/test_module_instance.py
+++ b/tests/test_module_instance.py
@@ -154,10 +154,10 @@ class TestElaboration:
             assert port["name"] in ["a", "b"]
             assert port["width"] == 7086
             if port["name"] == "a":
-                assert port["direction"] == "INPUT"
+                assert port["direction"] == "Input"
                 assert port["description"] == "Input A"
             else:
-                assert port["direction"] == "OUTPUT"
+                assert port["direction"] == "Output"
                 assert port["description"] == ""
 
 


### PR DESCRIPTION
## Features / Changes

- Remove SignalType Enum and its usage from Signal

## Background

We used SignalType to differentiate Signal instead of class type previously.
It was used to avoid circular import dependency.

We have learnt the following recently and flattened the source code, preventing a big `signal.py` monolith
```python
from __future__ import annotations
from typing import TYPE_CHECKING
if TYPE_CHECKING:
  ...
```
We can then remove this field from the signal config, and simplify the code.
